### PR TITLE
curl -> httpie json: curly braces were removed with curl --data '{"foo":"bar"}'

### DIFF
--- a/transformers/httpie/transformers.go
+++ b/transformers/httpie/transformers.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"strings"
 
+	"io/ioutil"
+
 	"github.com/dcb9/curl2httpie/curl"
 	"github.com/dcb9/curl2httpie/httpie"
-	"io/ioutil"
 )
 
 type Transformer func(cl *httpie.CmdLine, o *curl.Option)
@@ -57,7 +58,7 @@ func Data(cl *httpie.CmdLine, o *curl.Option) {
 
 	// try RAW JSON
 	var js json.RawMessage
-	err := json.Unmarshal([]byte(o.Arg[1:len(o.Arg)-1]), &js)
+	err := json.Unmarshal([]byte(o.Arg), &js)
 	if err != nil {
 		panic(ErrUnknownDataType)
 	}


### PR DESCRIPTION
I didn't know what the `o.Arg[1:len(o.Arg)-1]` was about (probably removing the first and last character) but simply having `o.Arg` instead makes things work 😁

    curl --request "POST" --header "Content-Type: application/json" --data '{"foo":"bar"}' https://httpbin.org/anything

gets translated into

    echo {"foo":"bar"} | http --json POST 'https://httpbin.org/anything'